### PR TITLE
Added vhosts support, new 'ansible' key in config.yml

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,5 +53,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Enable provisioning with Ansible.
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "provisioning/pubstack.yml"
+    ansible.extra_vars = pubstack_config["ansible"]
   end
 end

--- a/default.config.yml
+++ b/default.config.yml
@@ -6,3 +6,19 @@ vagrant:
 virtualbox:
   # Adjust the Base Memory provisioned for the VM:
   memory: "1024"
+
+ansible:
+  # Define a list of sites with the following keys:
+  #
+  # shortname       = site's shortname
+  # vhost           = assoc array with:
+  #   servername    = domain name
+  #   documentroot  = site docroot, relative to synced_folder
+  #
+  # Example:
+  #
+  # sites:
+  # - shortname: "site1"
+  #   vhost: {servername: "local.site1.com", documentroot: "site1/docroot"}
+  # - shortname: "site2"
+  #   vhost: {servername: "local.site2.com", documentroot: "site2/docroot"}

--- a/provisioning/roles/apache/tasks/main.yml
+++ b/provisioning/roles/apache/tasks/main.yml
@@ -7,8 +7,20 @@
   apt: name=libapache2-mod-php5 state=present
   sudo: yes
 
-- name: "start apache"
-  service: name=apache2 state=running enabled=yes
+- name: "add vhosts"
+  template: >
+    src=virtualhost.j2
+    dest=/etc/apache2/sites-enabled/{{ item.shortname }}
+    owner=root group=root mode=644
+  with_items: sites
+  when: sites is defined
+  notify: restart webserver
 
 - name: "copy index.html"
   copy: src=index.html dest=/var/www/index.html
+
+- name: "start apache"
+  service: >
+    name=apache2
+    state=started
+    enabled=yes

--- a/provisioning/roles/apache/templates/virtualhost.j2
+++ b/provisioning/roles/apache/templates/virtualhost.j2
@@ -1,0 +1,14 @@
+
+<VirtualHost *:{{ apache_listen_port }}>
+  ServerName {{ item.vhost.servername }}
+  DocumentRoot {{ apache_synced_folder }}/{{ item.vhost.documentroot }}
+  <Directory "{{ apache_synced_folder }}/{{ item.vhost.documentroot }}">
+    AllowOverride All
+    Options -Indexes FollowSymLinks
+    Order allow,deny
+    Allow from all
+  </Directory>
+{% if item.vhost.extra_parameters is defined %}
+  {{ item.vhost.extra_parameters }}
+{% endif %}
+</VirtualHost>

--- a/provisioning/roles/apache/vars/main.yml
+++ b/provisioning/roles/apache/vars/main.yml
@@ -1,0 +1,3 @@
+---
+apache_listen_port: 80
+apache_synced_folder: "/var/www/shared"


### PR DESCRIPTION
@ericduran @scottrigby @breathingrock This adds user-configurable vhosts to `config.yml`. There's a new `ansible` key in `config.yml`, which is passed to ansible -- for now, this just holds sites info, but we can add to it. Let me know what y'all think.
