### PR TITLE
Allow users to run vagrant from any directory not just the top level

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 # Load local config:
 require "yaml"
-pubstack_config = YAML::load_file("config.yml")
+pubstack_config = YAML::load_file(File.dirname(__FILE__) + "/config.yml")
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"


### PR DESCRIPTION
This lets you run vagrant provision from any directory :+1: 
