### PR TITLE
Separate developer playbook, with config toggle

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -8,6 +8,9 @@ virtualbox:
   memory: "1024"
 
 ansible:
+  # Whether to include the developer playbook:
+  include_developer: TRUE
+
   # Define a list of sites with the following keys:
   #
   # shortname       = site's shortname

--- a/provisioning/developer.yml
+++ b/provisioning/developer.yml
@@ -1,0 +1,6 @@
+---
+- hosts: all
+  sudo: yes
+  roles:
+  - php-xdebug
+  - php-xhprof

--- a/provisioning/pubstack.yml
+++ b/provisioning/pubstack.yml
@@ -1,2 +1,4 @@
 ---
 - include: webserver.yml
+- include: developer.yml
+  when: {{ item.include_developer }}

--- a/provisioning/webserver.yml
+++ b/provisioning/webserver.yml
@@ -8,8 +8,6 @@
   - php
   - php-mysql
   - php-pear
-  - php-xdebug
-  - php-xhprof
   - composer
   - drush
   handlers:


### PR DESCRIPTION
@ericduran @conortm This is so we can keep add dev additions in one toggle-able place
