### PR TITLE
Require a config.yml file & allow port-forwarding

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,9 +25,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
   # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  config.vm.network "forwarded_port", guest: 80, host: 8080
+  # within the machine from a port on the host machine.
+  # If you want to forward ports just follow the example in default.config.yml
+  if not pubstack_config["virtualbox"]["port-forwarding"].nil?
+    pubstack_config["virtualbox"]["port-forwarding"].each do |port|
+      config.vm.network "forwarded_port", guest: port['vm'], host: port['local']
+    end
+  end
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.

--- a/default.config.yml
+++ b/default.config.yml
@@ -6,6 +6,12 @@ vagrant:
 virtualbox:
   # Adjust the Base Memory provisioned for the VM:
   memory: "1024"
+  # Allow port-forwarding to be set up here.
+  # Ex: Forward port 80 to 8080.
+  # port-forwarding:
+  #   - name: http
+  #     vm: 80
+  #     local: 8080
 
 ansible:
   # Define a list of sites with the following keys:


### PR DESCRIPTION
This throws an error when anyone tries to run vagrant without setting up a config.yml ;-)
