### PR TITLE
Change JSON to YAML in default config

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -22,9 +22,12 @@ ansible:
   #   documentroot  = site docroot, relative to synced_folder
   #
   # Example:
-  #
-  # sites:
-  # - shortname: "site1"
-  #   vhost: {servername: "local.site1.com", documentroot: "site1/docroot"}
-  # - shortname: "site2"
-  #   vhost: {servername: "local.site2.com", documentroot: "site2/docroot"}
+  #  sites:
+  #  - shortname: "site1"
+  #    vhost:
+  #      servername: "local.site1.com"
+  #      documentroot: "site1/docroot"
+  #  - shortname: "site2"
+  #    vhost:
+  #      servername: "local.site2.com"
+  #      documentroot: "site2/docroot"


### PR DESCRIPTION
Also did minimal indentation change for IDEs (the comment key command keeps spacing properly this way, otherwise it added an extra space - surprisingly).
