### PR TITLE
Properly configure MySQL to match AQ environments

### DIFF
--- a/provisioning/roles/mysql/files/my.cnf
+++ b/provisioning/roles/mysql/files/my.cnf
@@ -1,0 +1,155 @@
+#
+# The MySQL database server configuration file.
+#
+# You can copy this to one of:
+# - "/etc/mysql/my.cnf" to set global options,
+# - "~/.my.cnf" to set user-specific options.
+#
+# One can use all long options that the program supports.
+# Run program with --help to get a list of available options and with
+# --print-defaults to see which it would actually understand and use.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+# This will be passed to all mysql clients
+# It has been reported that passwords should be enclosed with ticks/quotes
+# escpecially if they contain "#" chars...
+# Remember to edit /etc/mysql/debian.cnf when changing the socket location.
+[client]
+port            = 3306
+socket          = /var/run/mysqld/mysqld.sock
+
+# Here is entries for some specific programs
+# The following values assume you have at least 32M ram
+
+# This was formally known as [safe_mysqld]. Both versions are currently parsed.
+[mysqld_safe]
+socket          = /var/run/mysqld/mysqld.sock
+nice            = 0
+
+[mysqld]
+#
+# * Basic Settings
+#
+user            = mysql
+pid-file        = /var/run/mysqld/mysqld.pid
+socket          = /var/run/mysqld/mysqld.sock
+port            = 3306
+basedir         = /usr
+datadir         = /var/lib/mysql
+tmpdir          = /tmp
+lc-messages-dir = /usr/share/mysql
+skip-external-locking
+#
+# Instead of skip-networking the default is now to listen only on
+# localhost which is more compatible and is not less secure.
+# pubstack comments this out so we can access it remotely.
+#bind-address            = 127.0.0.1
+
+####################
+# AQ Settings      #
+####################
+character-set-server = utf8
+collation-server = utf8_general_ci
+
+query_cache_size=40M #This is about as much as we are going to want
+key_buffer_size=20M #Settings this to something reasonable for temp tables
+join_buffer_size=512K
+read_buffer_size=512K
+read_rnd_buffer_size=512K
+sort_buffer_size=512K
+table_cache=2500
+thread_cache_size=200
+max_allowed_packet=100M
+query_cache_limit=5M
+query_cache_min_res_unit=1024
+max_connect_errors=9999999
+wait_timeout=600
+net_write_timeout=600
+interactive_timeout=600
+log_queries_not_using_indexes=0
+slow_query_log=1
+long_query_time=1
+
+auto_increment_increment        = 5
+
+
+#####################
+# AQ Settings END   #
+#####################
+
+#
+# * Fine Tuning
+#
+thread_stack            = 192K
+thread_cache_size       = 8
+# This replaces the startup script and checks MyISAM tables if needed
+# the first time they are touched
+myisam-recover         = BACKUP
+#max_connections        = 100
+#table_cache            = 64
+#thread_concurrency     = 10
+#
+#
+# * Logging and Replication
+#
+# Both location gets rotated by the cronjob.
+# Be aware that this log type is a performance killer.
+# As of 5.1 you can enable the log at runtime!
+#general_log_file        = /var/log/mysql/mysql.log
+#general_log             = 1
+#
+# Error log - should be very few entries.
+#
+log_error = /var/log/mysql/error.log
+#
+# Here you can see queries with especially long duration
+#log_slow_queries       = /var/log/mysql/mysql-slow.log
+#long_query_time = 2
+#log-queries-not-using-indexes
+#
+# The following can be used as easy to replay backup logs or for replication.
+# note: if you are setting up a replication slave, see README.Debian about
+#       other settings you may need to change.
+#server-id              = 1
+#log_bin                        = /var/log/mysql/mysql-bin.log
+expire_logs_days        = 10
+max_binlog_size         = 100M
+#binlog_do_db           = include_database_name
+#binlog_ignore_db       = include_database_name
+#
+# * InnoDB
+#
+# InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
+# Read the manual for more InnoDB related options. There are many!
+#
+# * Security Features
+#
+# Read the manual, too, if you want chroot!
+# chroot = /var/lib/mysql/
+#
+# For generating SSL certificates I recommend the OpenSSL GUI "tinyca".
+#
+# ssl-ca=/etc/mysql/cacert.pem
+# ssl-cert=/etc/mysql/server-cert.pem
+# ssl-key=/etc/mysql/server-key.pem
+
+
+
+[mysqldump]
+quick
+quote-names
+max_allowed_packet      = 16M
+
+[mysql]
+#no-auto-rehash # faster start of mysql but no tab completition
+
+[isamchk]
+key_buffer              = 16M
+
+#
+# * IMPORTANT: Additional settings that can override those from this file!
+#   The files must end with '.cnf', otherwise they'll be ignored.
+#
+!includedir /etc/mysql/conf.d/

--- a/provisioning/roles/mysql/tasks/main.yml
+++ b/provisioning/roles/mysql/tasks/main.yml
@@ -3,8 +3,14 @@
   apt: name={{ item }} state=present
   with_items: mysql_apt_packages
 
+- name: "copy my.cnf"
+  copy: src=my.cnf dest=/etc/mysql/my.cnf
+
 - name: start mysql service
   service: name=mysql state=started enabled=true
+
+- name: "allow remote root login"
+  shell: mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '' WITH GRANT OPTION; FLUSH PRIVILEGES;"
 
 - name: create site database
   mysql_db: name={{ item.shortname }} state=present collation=utf8_general_ci
@@ -12,6 +18,6 @@
   when: sites is defined
 
 - name: create database user
-  mysql_user: name={{ item.shortname }} password= priv={{ item.shortname }}.*:ALL host=localhost state=present
+  mysql_user: name={{ item.shortname }} password= priv={{ item.shortname }}.*:ALL host=% state=present
   with_items: sites
   when: sites is defined


### PR DESCRIPTION
So at 1st I was trying to access MySQL from my local without having to do anything.

That was not possible because by default mysql, can only listen on 127.0.0.1, so I fixed the mysql config to listen on all ip address so now mysql or sequel pro can properly connect to our MySQL instance without needing an ssh tunnel.

While I was at it I went ahead and added all the AQ settings, this matches their configs for everything except the Percona specific stuff since we're still running mysql.

This also does acquia weird settings like the auto_increment_increment value, so this is as close as we can get with out running percona :+1: 
