### PR TITLE
Move the default vm under dev config block (needed for solr & "stage" env)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,34 +34,33 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # doesn't already exist on the user's system.
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  config.vm.network "private_network", ip: "172.20.20.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
-
   # If true, then any SSH connections made will enable agent forwarding.
   # Default value: false
   config.ssh.forward_agent = true
 
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  config.vm.synced_folder pubstack_config["vagrant"]["synced_folder"], "/var/www/html"
+  # Set up the config inside a block to allow for multiple-machines in
+  # the future. This way the default box won't be lost when we update.
+  config.vm.define "dev" do |dev|
+    # Create a private network, which allows host-only access to the machine
+    # using a specific IP.
+    dev.vm.network "private_network", ip: "172.20.20.10"
 
-  # Provider-specific configuration for VirtualBox:
-  config.vm.provider "virtualbox" do |vb|
-    # Use VBoxManage to customize the VM. For example to change memory:
-    vb.customize ["modifyvm", :id, "--memory", pubstack_config["virtualbox"]["memory"]]
-  end
+    # Share an additional folder to the guest VM. The first argument is
+    # the path on the host to the actual folder. The second argument is
+    # the path on the guest to mount the folder. And the optional third
+    # argument is a set of non-required options.
+    dev.vm.synced_folder pubstack_config["vagrant"]["synced_folder"], "/var/www/html"
 
-  # Enable provisioning with Ansible.
-  config.vm.provision "ansible" do |ansible|
-    ansible.playbook = "provisioning/pubstack.yml"
-    ansible.extra_vars = pubstack_config["ansible"]
+    # Provider-specific configuration for VirtualBox:
+    dev.vm.provider "virtualbox" do |vb|
+      # Use VBoxManage to customize the VM. For example to change memory:
+      vb.customize ["modifyvm", :id, "--memory", pubstack_config["virtualbox"]["memory"]]
+    end
+
+    # Enable provisioning with Ansible.
+    dev.vm.provision "ansible" do |ansible|
+      ansible.playbook = "provisioning/pubstack.yml"
+      ansible.extra_vars = pubstack_config["ansible"]
+    end
   end
 end


### PR DESCRIPTION
This moves all the default config to work under a specific "dev" box.

I ran into this issue when setting up the Solr config, this is also going to be require for https://github.com/NBCUOTS/pubstack/pull/32

We need to do this before shipping because what happens is, if we have a box already and we move the default under a config it looses the default box. This just happened to me when setting up the solr box.

So we should only have generic vagrant setting in the `config.vm` object and always have anything specific to a box under the `boxkey.config.vm` object.
