### PR TITLE
Add appropriate Vagrant command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Publisher's DevStack
     vim config.yml
     ```
 
-    **NOTE:** after the initial `vagrant up`, any time you edit your config file values you will want to run `vagrant reload`.
+    **NOTE:** after the initial `vagrant up`, any time you edit your config file values you will want to run `vagrant reload --provision`.
 
 1. Start-up your vagrant box:
 


### PR DESCRIPTION
Partially reverses the provision note removed in 4ca7b81e4a, but updated for Hostupdater.
CC @ericduran @conortm @breathingrock 
