### PR TITLE
Add base_url - makes drush uli easier, etc

### DIFF
--- a/provisioning/roles/drupal/templates/settings.j2
+++ b/provisioning/roles/drupal/templates/settings.j2
@@ -1,5 +1,7 @@
 <?php
 
+$base_url = 'http://{{ item.vhost.servername }}';
+
 $databases['default'] = array ('default' =>
   array (
     'database' => '{{ item.shortname }}',


### PR DESCRIPTION
CC @ericduran @conortm 

**Example:**
`drush uli`

**Before:** 
`http://install/user/reset/1/1406664772/TU3RvC1uOSyAa6AGrMjunSD5CINXWyJjua5h9aCopdo/login`
**After:** 
`http://local.install.publisher7.com/user/reset/1/1406666559/rrSrxJd1Eu6RPU3LsG_UFAzP0ikX5SB1b5s55mIaVjo/login`

Any objections?
