### PR TITLE
Xdebug cli settings

### DIFF
--- a/provisioning/roles/php-xdebug/tasks/main.yml
+++ b/provisioning/roles/php-xdebug/tasks/main.yml
@@ -18,3 +18,9 @@
   notify:
     - restart webserver
     - restart php-fpm
+
+- name: "xdebug cli"
+  template: src=xdebug_cli.ini.j2 dest=/etc/php5/cli/conf.d/xdebug.ini
+  notify:
+    - restart webserver
+    - restart php-fpm

--- a/provisioning/roles/php-xdebug/templates/xdebug_cli.ini.j2
+++ b/provisioning/roles/php-xdebug/templates/xdebug_cli.ini.j2
@@ -1,0 +1,7 @@
+zend_extension={{ php_xdebug_so_path.stdout }}
+xdebug.remote_enable  = 1
+xdebug.remote_host    = 10.0.2.2
+xdebug.remote_port    = 9000
+xdebug.remote_handler = dbgp
+xdebug.remote_autostart=0
+xdebug.idekey=PHPSTORM


### PR DESCRIPTION
@ericduran @conortm 

Allows Xdebug on the command line.

There are also steps needed (for now, before we generate that automatically) in PhpStorm to make it work properly (namely `export XDEBUG_CONFIG="idekey={{ xdebug_idekey }}"; export PHP_IDE_CONFIG="serverName=publisher"
`).
