### PR TITLE
Splunk improvements

### DIFF
--- a/provisioning/roles/splunk/tasks/main.yml
+++ b/provisioning/roles/splunk/tasks/main.yml
@@ -28,10 +28,15 @@
 - name: "Flush notify handlers"
   meta: flush_handlers
 
+- name: "Adding logs to Splunk monitor"
+  command: /opt/splunk/bin/splunk list monitor -auth admin:changeme
+  register: splunk_result
+  changed_when: "'/var/log/syslog' not in splunk_result.stdout"
+
 - name: "Monitor Syslog"
   command: /opt/splunk/bin/splunk add monitor /var/log/syslog -auth admin:changeme
-  ignore_errors: yes
+  when: "'/var/log/syslog' not in splunk_result.stdout"
 
 - name: "Monitor Apache error log"
   command: /opt/splunk/bin/splunk add monitor /var/log/apache2/error.log -auth admin:changeme
-  ignore_errors: yes
+  when: "'/var/log/apache2/error.log' not in splunk_result.stdout"


### PR DESCRIPTION
When Splunk is already monitoring a file, Pubstack will not try to add it again.
