### PR TITLE
Fixed tmp dir creation and perms; Removed innodb log config

### DIFF
--- a/provisioning/roles/mysql/files/my.cnf
+++ b/provisioning/roles/mysql/files/my.cnf
@@ -61,7 +61,7 @@ slow_query_log=1
 long_query_time=1
 
 #Variable
-innodb_buffer_pool_size = 19382927360
+innodb_buffer_pool_size = 8M
 innodb_thread_concurrency = 8
 
 # To compute max connections, we take mysqld's total percentage of memory 
@@ -89,9 +89,6 @@ innodb_file_format = Barracuda
 default_storage_engine = INNODB
 innodb_data_file_path=ibdata1:10M:autoextend
 innodb_flush_method=O_DIRECT
-innodb_log_file_size=200M
-innodb_log_files_in_group=3
-innodb_log_buffer_size=8M
 # innodb_flush_log_at_trx_commit:
 #  0: Log buffer is written out to the log file once per second and the flush
 #     to disk operation is performed on the log file, but nothing is done at a

--- a/provisioning/roles/mysql/tasks/main.yml
+++ b/provisioning/roles/mysql/tasks/main.yml
@@ -32,6 +32,9 @@
   notify:
   - restart mysql
 
+- name: "Setup mysql tmp directory"
+  file: path=/tmp/mysql owner=mysql group=mysql state=directory mode="a+rwx"
+
 - name: start mysql service
   service: name=mysql state=started enabled=true
 

--- a/provisioning/roles/php-xhprof/tasks/main.yml
+++ b/provisioning/roles/php-xhprof/tasks/main.yml
@@ -15,4 +15,4 @@
   notify: restart webserver
 
 - name: "Setup xhprof tmp directory"
-  file: path=/tmp/xhprof owner=www-data group=www-data state=directory
+  file: path=/tmp/xhprof owner=www-data group=www-data state=directory mode="a+rwx"


### PR DESCRIPTION
On `vagrant destroy` and `vagrant up`ing again, mysql would not start because:
1. tmp dir was not writeable
2. weird error that innodb log files were the wrong size...

Anyway, these changes resolve that issue.

Fixes #152
