### PR TITLE
Run the Cisco workaround with vagrant commands

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,6 +33,18 @@ if (RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/)
   synced_folder_type = 'smb'
 end
 
+# Run the firewall fixer script if Mac and the config file doesn't say otherwise.
+unless pubstack_config['mac_firewall_script'] == false
+  if RbConfig::CONFIG['host_os'][0,6] = 'darwin'
+    darwinVersion = Integer(RbConfig::CONFIG['host_os'][7,8])
+    if darwinVersion > 13
+      # @TODO: ipfw removed in Yosemite and above. HTF does `pf` work?
+    else
+      `./scripts/cisco.workaround.sh`
+    end
+  end
+end
+
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = '2'
 


### PR DESCRIPTION
We should just run the Cisco workaround script when appropriate.
Unfortunately, it's unlikely that the script will work on Yosemite
and up because `ipfw` doesn't exist anymore (it's now pf, which is
some weird BSD thing I've never heard of/used). Right now, no action
will be taken if the host os is Yosemite or newer, but we should
figure out how to make pf cooperate and add it later.
