### PR TITLE
Updated drush to 7.x

### DIFF
--- a/provisioning/roles/drush/tasks/main.yml
+++ b/provisioning/roles/drush/tasks/main.yml
@@ -17,6 +17,10 @@
   file: src={{ drush_install_path }}/drush dest={{ drush_path }} state=link
   tags: drush
 
+- name: "create drush6 symlink"
+  file: src={{ drush_path }} dest={{ drush6_path }} state=link
+  tags: drush
+
 - name: "run drush to finish setting it up"
   command: "{{ drush_path }}"
   register: drush_result
@@ -35,4 +39,22 @@
     regexp="^.*drush_bashrc"
     line="if [ -f ~/.drush_bashrc ] ; then . ~/.drush_bashrc ; fi"
     state=present
+  tags: drush
+
+- name: "clone drush7 from github"
+  git: >
+    repo=https://github.com/drush-ops/drush.git
+    dest={{ drush7_install_path }}
+    version={{ drush7_version }}
+  tags: drush
+
+- name: "install drush7 dependencies with composer"
+  shell: >
+    composer install
+    chdir={{ drush7_install_path }}
+    creates={{ drush7_install_path }}/vendor/autoload.php
+  tags: drush
+
+- name: "create drush7 symlink"
+  file: src={{ drush7_install_path }}/drush dest={{ drush7_path }} state=link
   tags: drush

--- a/provisioning/roles/drush/vars/main.yml
+++ b/provisioning/roles/drush/vars/main.yml
@@ -1,4 +1,8 @@
 ---
 drush_install_path: /usr/local/share/drush
 drush_path: /usr/local/bin/drush
-drush_version: 7.0.0-alpha8
+drush_version: 6.x
+drush6_path: /usr/local/bin/drush6
+drush7_install_path: /usr/local/share/drush7
+drush7_path: /usr/local/bin/drush7
+drush7_version: 7.0.0-alpha8


### PR DESCRIPTION
**Description**

Update drush to 7.x so we use pubstack to work on Drupal 8.
