### PR TITLE
Increase function nesting level for D8

### DIFF
--- a/provisioning/roles/php-xdebug/templates/xdebug.ini.j2
+++ b/provisioning/roles/php-xdebug/templates/xdebug.ini.j2
@@ -6,3 +6,4 @@ xdebug.remote_handler={{ xdebug_remote_handler }}
 xdebug.remote_connect_back= {{ xdebug_remote_connect_back }}
 xdebug.remote_autostart={{ xdebug_remote_autostart }}
 xdebug.idekey="{{ xdebug_idekey }}"
+xdebug.max_nesting_level={{ xdebug_max_nesting_level }}

--- a/provisioning/roles/php-xdebug/vars/main.yml
+++ b/provisioning/roles/php-xdebug/vars/main.yml
@@ -6,3 +6,4 @@ xdebug_remote_handler: dbgp
 xdebug_remote_connect_back: 1
 xdebug_remote_autostart: On
 xdebug_idekey: PHPSTORM
+xdebug_max_nesting_level: 500


### PR DESCRIPTION
**Description**
Drupal 8 has an insane function nesting level (don't ask why).
So we need to increase xdebug's max_nesting_level to even do something
like node/add/article.
