### PR TITLE
Add the ability to mount arbitrary folders in the VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,13 @@ if pubstack_config.include? 'synced_folder'
   end
 
   pubstack_config['sites'].each {|site|
+    # Since we know the host path and the VM path in this specific case,
+    # we can do documentroot validation.
+    documentroot = pubstack_config['synced_folder'] + '/' + site['vhost']['documentroot']
+    if not File.directory? (File.expand_path(documentroot))
+      raise Vagrant::Errors::VagrantError.new, 'The docroot ' + documentroot + ' does not exist.'
+    end
+
     site['vhost']['documentroot'] = '/var/www/html/' + site['vhost']['documentroot']
   }
   pubstack_config['shared_folders'] = [ { "map" => pubstack_config['synced_folder'], "to" => '/var/www/html'} ]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ if pubstack_config.include? 'synced_folder'
   # and the path to the documentroot in the VM will break, so just bail
   # if both are specified for whatever reason.
   if pubstack_config.include? 'shared_folders'
-    raise Vagrant::Errors::VagrantError.new, 'You may only use the synced_folder option if synced_folders is not specified. Please fix your config.yml and try again.'
+    raise Vagrant::Errors::VagrantError.new, 'You may only use the synced_folder option if shared_folders is not specified. Please fix your config.yml and try again.'
   end
 
   pubstack_config['sites'].each {|site|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,10 +12,10 @@ pubstack_config = YAML::load_file(config_file)
 # If the synced folder option is specified, fix the documentroot option
 # for every site.
 if pubstack_config.include? 'synced_folder'
-  # It doesn't make sense to specify both synced_folder and synced_folders,
+  # It doesn't make sense to specify both synced_folder and shared_folders,
   # and the path to the documentroot in the VM will break, so just bail
   # if both are specified for whatever reason.
-  if pubstack_config.include? 'synced_folders'
+  if pubstack_config.include? 'shared_folders'
     raise Vagrant::Errors::VagrantError.new, 'You may only use the synced_folder option if synced_folders is not specified. Please fix your config.yml and try again.'
   end
 
@@ -23,6 +23,11 @@ if pubstack_config.include? 'synced_folder'
     site['vhost']['documentroot'] = '/var/www/html/' + site['vhost']['documentroot']
   }
   pubstack_config['shared_folders'] = [ { "map" => pubstack_config['synced_folder'], "to" => '/var/www/html'} ]
+end
+
+# Ensure that the shared_folders configuration exists.
+if not pubstack_config.include? 'shared_folders'
+  raise Vagrant::Errors::VagrantError.new, 'You must include either the synced_folder or shared_folders options in your config.yml'
 end
 
 # Ensure that the new config dictionary exists.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,11 @@ if not File.file?(config_file)
 end
 pubstack_config = YAML::load_file(config_file)
 
+# Ensure that the sites key exists.
+if not pubstack_config.include? 'sites'
+  raise Vagrant::Errors::VagrantError.new, "You must include the sites key in your config.yml. See config.example.yml for an example."
+end
+
 # If the synced folder option is specified, fix the documentroot option
 # for every site.
 if pubstack_config.include? 'synced_folder'

--- a/config.example.multiple_shares.yml
+++ b/config.example.multiple_shares.yml
@@ -1,0 +1,31 @@
+---
+memory: 1024
+cpus: 2
+
+shared_folders:
+  - map: ~/Documents/Code/NBCU/Sites
+    to: /var/www/html
+  - map: ~/Documents/Code/some_other_thing/drupal
+    to: /var/www/some_other_thing
+
+sites:
+- subscription: nbcupublisher7
+  shortname: nbcupublisher7
+  vhost:
+    servername: local.publisher7.com
+    documentroot: /var/www/html/Publisher7/docroot
+
+- subscription: some_other_thing
+  shortname: some_other_thing
+  vhost:
+    servername: some_other_thing.dev
+    documentroot: /var/www/some_other_thing
+
+config:
+  nodejs: false
+  phantomjs: false
+  ruby: true
+  splunk: false
+  mailcatcher: true
+
+

--- a/config.example.yml
+++ b/config.example.yml
@@ -11,8 +11,10 @@ cpus: 2
 # - shortname: The site's shortname.
 # - vhost: An associative array, containing:
 #   - servername: The domain.
-#   - documentroot: Path to the site docroot, relative to synced_folder. Note
-#     this directory must exist on your machine before running Vagrant.
+#   - documentroot: Path to the site docroot in the VM. If you're using the
+#     synced_folder option, you only need to specify the path relative to
+#     your synced folder. Otherwise, you need to specify the full path to
+#     the docroot inside of the VM.
 #
 # Example:
 sites:

--- a/provisioning/roles/apache/templates/virtualhost.j2
+++ b/provisioning/roles/apache/templates/virtualhost.j2
@@ -1,8 +1,8 @@
 
 <VirtualHost *:{{ apache_listen_port }}>
   ServerName {{ item.vhost.servername }}
-  DocumentRoot {{ apache_synced_folder }}/{{ item.vhost.documentroot }}
-  <Directory "{{ apache_synced_folder }}/{{ item.vhost.documentroot }}">
+  DocumentRoot {{ item.vhost.documentroot }}
+  <Directory "{{ item.vhost.documentroot }}">
     Order Deny,Allow
     Allow from all
     Options FollowSymLinks ExecCGI


### PR DESCRIPTION
First off - this PR won't break the existing config.

Here's a list of what changes:

- ~~The documentroot for each site now refers to the path inside of the VM, so validation of the docroot path doesn't make sense anymore and has been removed.~~ docroot validation still works for users that are still using `synced_folder`. Users that opt for `shared_folders` will be responsible for ensuring that their config works.
- If the `synced_folder` option is specified (as it has been in all previous configurations), the documentroot for each site is silently updated to reflect the default path in the vm (`/var/www/html/ + site_docroot`).
- If the `shared_folders` option is specified, the developer can mount any arbitrary folder in the VM at any path. This is considered to be more advanced functionality, so if the developer does something weird like mounting a folder at `/etc` or something, it's not our problem.

This is useful because I have all of my NBC code in `~/Documents/Code/NBCU`, but I also want to be able to use the VM for non-NBC stuff (i.e. Drupal 8 contribution and such).