### PR TITLE
upgrades config.vm.box to 'ubuntu/trusty64'

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,11 +70,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = 'pubstack'
-
-  # The url from where the 'config.vm.box' box will be fetched if it
-  # doesn't already exist on the user's system.
-  config.vm.box_url = 'http://files.vagrantup.com/precise64.box'
+  config.vm.box = 'ubuntu/trusty64'
 
   # If true, then any SSH connections made will enable agent forwarding.
   # Default value: false

--- a/provisioning/roles/apache/tasks/main.yml
+++ b/provisioning/roles/apache/tasks/main.yml
@@ -12,14 +12,14 @@
     src=virtualhost.j2
     dest=/etc/apache2/sites-available/{{ item.shortname }}.conf
     owner=root group=root mode=644
-  with_items: sites
+  with_items: "{{ sites }}"
   when: sites is defined
   notify: restart webserver
   sudo: yes
 
 - name: "enable vhosts"
   shell: a2ensite {{ item.shortname }}.conf
-  with_items: sites
+  with_items: "{{ sites }}"
   when: sites is defined
   register: a2ensite_result
   changed_when: "'Enabling site' in a2ensite_result.stdout"
@@ -56,12 +56,12 @@
     state=started
     enabled=yes
 
-- name: Add hosts entry for each site.
+- name: "Add hosts entry for each site."
   lineinfile:
     dest=/etc/hosts
     line="127.0.0.1  {{ item.vhost.servername }}"
     insertafter=EOF
-  with_items: sites
+  with_items: "{{ sites }}"
 
 # We can not add this to the global /var/www/sitescripts/siteinfo.php because
 # ah_site_info() supplies not only environment but project info, and we support

--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- name: ensure Apache PPA is enabled
+- name: "ensure Apache PPA is enabled"
   apt_repository: repo='ppa:ondrej/apache2'
 
-- name: ensure PHP PPA is enabled
+- name: "ensure PHP PPA is enabled"
   apt_repository: repo='ppa:ondrej/php5'
 
 - name: "update apt cache"
@@ -10,7 +10,7 @@
 
 - name: "install common packages"
   apt: pkg={{ item }} state=present
-  with_items: common_apt_packages
+  with_items: "{{ common_apt_packages }}"
 
-- name: Copy host.conf so curl can resolve host names
+- name: "Copy host.conf so curl can resolve host names"
   copy: src=host.conf dest=/etc/host.conf

--- a/provisioning/roles/drupal/tasks/main.yml
+++ b/provisioning/roles/drupal/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "create site-php directory"
   file: path=/var/www/site-php/{{ item.subscription }} state=directory
-  with_items: sites
+  with_items: "{{ sites }}"
   when: sites is defined
   sudo: yes
 
@@ -11,7 +11,7 @@
     src=settings.j2
     dest=/var/www/site-php/{{ item.subscription }}/{{ item.shortname }}-settings.inc
     owner=root group=root mode=644
-  with_items: sites
+  with_items: "{{ sites }}"
   when: sites is defined
   sudo: yes
 
@@ -20,7 +20,7 @@
     src=d7-settings.j2
     dest=/var/www/site-php/{{ item.subscription }}/D7-{{ item.shortname }}-settings.inc
     owner=root group=root mode=644
-  with_items: sites
+  with_items: "{{ sites }}"
   when: sites is defined
   sudo: yes
 
@@ -29,6 +29,6 @@
     src=d8-settings.j2
     dest=/var/www/site-php/{{ item.subscription }}/D8-{{ item.shortname }}-settings.inc
     owner=root group=root mode=644
-  with_items: sites
+  with_items: "{{ sites }}"
   when: sites is defined
   sudo: yes

--- a/provisioning/roles/mailcatcher/tasks/main.yml
+++ b/provisioning/roles/mailcatcher/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # tasks file for role-mailcatcher
-- name: Install required software
+- name: "Install required software"
   apt: pkg={{ item }} state=latest
   with_items:
       - sqlite3
@@ -8,49 +8,49 @@
       - ruby-dev
       - rubygems
 
-- name: Install dependencies
+- name: "Install dependencies"
   gem: name=mime-types version=1.25.1 state=present user_install=no
 
-- name: Install Mailcatcher
+- name: "Install Mailcatcher"
   gem: name=mailcatcher state=latest user_install=no
 
-- name: Create startup script
+- name: "Create startup script"
   copy: src=mailcatcher dest=/etc/init.d/mailcatcher mode=0755
   register: mailcatcher_init_status
 
-- name: Make sure Mailcatcher is not running
+- name: "Make sure Mailcatcher is not running"
   command: pkill mailcatcher
   ignore_errors: yes
   when: mailcatcher_init_status.changed
 
-- name: Start Mailcatcher and start it on boot
+- name: "Start Mailcatcher and start it on boot"
   service: name=mailcatcher state=started enabled=yes
   when: mailcatcher_init_status.changed
 
-- name: Reset PHP's sendmail handler (fpm)
+- name: "Reset PHP's sendmail handler (fpm)"
   copy: src=php-mailcatcher.ini dest=/etc/php5/fpm/conf.d/mailcatcher.ini mode=0644
   notify:
     - restart webserver
     - restart php-fpm
 
-- name: Reset PHP's sendmail handler (cli)
+- name: "Reset PHP's sendmail handler (cli)"
   copy: src=php-mailcatcher.ini dest=/etc/php5/cli/conf.d/mailcatcher.ini mode=0644
   notify:
     - restart webserver
     - restart php-fpm
 
-- name: Reset PHP CLI sendmail handler
+- name: "Reset PHP CLI sendmail handler"
   ini_file: dest=/etc/php5/cli/php.ini section="mail function" option=sendmail_path value="/usr/bin/env catchmail"
 
-- name: Enable required Apache modules for mail subdomain
+- name: "Enable required Apache modules for mail subdomain"
   shell: a2enmod proxy proxy_http
   register: a2enmod_result
   changed_when: "'already enabled' not in a2enmod_result.stdout"
 
-- name: Copy vhost settings
+- name: "Copy vhost settings"
   copy: src=mailcatcher.conf dest=/etc/apache2/sites-available/mailcatcher.conf
 
-- name: Enable Mailcatcher vhost
+- name: "Enable Mailcatcher vhost"
   shell: a2ensite mailcatcher.conf
   register: a2ensite_result
   changed_when: "'Enabling site mailcatcher' in a2ensite_result.stdout"

--- a/provisioning/roles/mysql/tasks/main.yml
+++ b/provisioning/roles/mysql/tasks/main.yml
@@ -1,29 +1,29 @@
 ---
-- name: Add Percona apt signing key
+- name: "Add Percona apt signing key"
   sudo: yes
   apt_key: keyserver=keys.gnupg.net id=1C4CBDCDCD2EFD2A state=present
 
-- name: Add Percona repository
+- name: "Add Percona repository"
   sudo: yes
   apt_repository: repo='deb http://repo.percona.com/apt precise main' state=present
 
-- name: Add Percona source repository
+- name: "Add Percona source repository"
   sudo: yes
   apt_repository: repo='deb-src http://repo.percona.com/apt precise main' state=present
 
-- name: Update apt cache
+- name: "Update apt cache"
   sudo: yes
   apt: update_cache=yes
 
-- name: Install python packages
+- name: "Install python packages"
   sudo: yes
   apt: name={{ item }} state=present
-  with_items: mysql_apt_packages
+  with_items: "{{ mysql_apt_packages }}"
 
-- name: Install Percona packages
+- name: "Install Percona packages"
   sudo: yes
   apt: name={{ item }} state=present update_cache=yes
-  with_items: percona_server_packages
+  with_items: "{{ percona_server_packages }}"
   environment:
     DEBIAN_FRONTEND: noninteractive
 
@@ -32,7 +32,7 @@
   notify:
   - restart mysql
 
-- name: start mysql service
+- name: "start mysql service"
   service: name=mysql state=started enabled=true
 
 - name: "allow remote root login"
@@ -40,12 +40,12 @@
   notify:
   - restart mysql
 
-- name: create site database
+- name: "create site database"
   mysql_db: name={{ item.shortname }} state=present collation=utf8_general_ci
-  with_items: sites
+  with_items: "{{ sites }}"
   when: sites is defined
 
-- name: create database user
+- name: "create database user"
   mysql_user: name={{ item.shortname }} password= priv={{ item.shortname }}.*:ALL host=% state=present
-  with_items: sites
+  with_items: "{{ sites }}"
   when: sites is defined

--- a/provisioning/roles/nfs/tasks/main.yml
+++ b/provisioning/roles/nfs/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
-- name: Install nfs packages
+- name: "Install nfs packages"
   apt: name={{ item }} state=present
   with_items:
     - cachefilesd
   notify:
     - restart webserver
 
-- name: Ensure cachefilesd exists
+- name: "Ensure cachefilesd exists"
   template: src=cachefilesd.j2 dest=/etc/default/cachefilesd owner=root group=root
 
-- name: Ensure cachefilesd service is started
+- name: "Ensure cachefilesd service is started"
   service: name=cachefilesd state=started
   ignore_errors: yes

--- a/provisioning/roles/nodejs/tasks/main.yml
+++ b/provisioning/roles/nodejs/tasks/main.yml
@@ -4,8 +4,8 @@
 
 - name: "install Node.js packages"
   apt: name={{ item }} state=latest
-  with_items: nodejs_apt_packages
+  with_items: "{{ nodejs_apt_packages }}"
 
 - name: "install global npm packages"
   npm: name={{ item }} global=yes state=latest
-  with_items: npm_global_packages
+  with_items: "{{ npm_global_packages }}"

--- a/provisioning/roles/phantomjs/tasks/main.yml
+++ b/provisioning/roles/phantomjs/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: "Install global npm packages"
   npm: name={{ item }} global=yes state=latest
-  with_items: phantomjs_nodejs_global_packages
+  with_items: "{{ phantomjs_nodejs_global_packages }}"
 
 - name: "Install PhantomJS 2 dependencies"
   apt: name={{ item }} state=present
   sudo: yes
-  with_items: phantomjs_global_dependencies
+  with_items: "{{ phantomjs_global_dependencies }}"
 
 - name: "Copy phantomjs2"
   copy: src=phantomjs dest=/usr/bin/phantomjs mode=0755

--- a/provisioning/roles/php-pear/tasks/main.yml
+++ b/provisioning/roles/php-pear/tasks/main.yml
@@ -15,11 +15,11 @@
   register: channel_result
   changed_when: "'already initialized' not in channel_result.stdout"
   failed_when: "channel_result.stderr"
-  with_items: pear_channels
+  with_items: "{{ pear_channels }}"
 
 - name: "install PEAR libraries"
   command: pear install {{ item }}
   register: pear_result
   changed_when: "'already installed' not in pear_result.stdout"
   failed_when: "pear_result.stderr"
-  with_items: pear_libraries
+  with_items: "{{ pear_libraries }}"

--- a/provisioning/roles/php/tasks/main.yml
+++ b/provisioning/roles/php/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "install php"
   apt: name={{ item }} state=present
-  with_items: php_apt_packages
+  with_items: "{{ php_apt_packages }}"
   notify:
     - restart webserver
 

--- a/provisioning/roles/ruby/tasks/main.yml
+++ b/provisioning/roles/ruby/tasks/main.yml
@@ -16,13 +16,17 @@
     chdir={{ workspace }}
     creates={{ workspace }}/ruby-{{ ruby_version }}
 
+- name: "install libffi-dev"
+  apt: name=libffi-dev state=present
+  sudo: yes
+
 - name: "build ruby"
   command: >
     {{ item }}
     chdir={{ workspace }}/ruby-{{ ruby_version }}
     creates=/usr/local/bin/ruby
   with_items:
-    - ./configure --enable-shared
+    - ./configure
     - make
     - sudo make install
 
@@ -31,6 +35,7 @@
     src=/usr/local/bin/{{ item }}
     dest=/usr/bin/{{ item }}
     state=link
+    force=yes
   with_items:
     - erb
     - gem

--- a/provisioning/roles/ruby/tasks/main.yml
+++ b/provisioning/roles/ruby/tasks/main.yml
@@ -47,5 +47,5 @@
 
 - name: "install ruby gems"
   gem: name={{ item }} state=present user_install=no
-  with_items: ruby_gems
+  with_items: "{{ ruby_gems }}"
   sudo: yes

--- a/provisioning/roles/ruby/vars/main.yml
+++ b/provisioning/roles/ruby/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 workspace: /home/vagrant
-ruby_download_url: http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz
-ruby_version: 2.1.5
+ruby_download_url: http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz
+ruby_version: 2.2.5
 ruby_gems:
   - bundler


### PR DESCRIPTION
The [PPA](https://launchpad.net/~ondrej/+archive/ubuntu/apache2) that is being installed for `apache2` and `ibapache2-mod-fastcgi` has been updated and the minimum version for Ubuntu is currently [14.04 LTS (Trusty Tahr)](http://releases.ubuntu.com/14.04/).

Upgrading to [14.04](https://atlas.hashicorp.com/ubuntu/boxes/trusty64) helped resolve this error:

```bash
fatal: [dev]: FAILED! => {"cache_update_time": 0, "cache_updated": false, "changed": false, "failed": true, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"   install 'apache2'' failed: E: Unmet dependencies. Try 'apt-get -f install' with no packages (or specify a solution).\n", "stderr": "E: Unmet dependencies. Try 'apt-get -f install' with no packages (or specify a solution).\n", "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nYou might want to run 'apt-get -f install' to correct these:\nThe following packages have unmet dependencies:\n libapache2-mod-fastcgi : Depends: apache2.2-common (>= 2.2.4) but it is not going to be installed\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "You might want to run 'apt-get -f install' to correct these:", "The following packages have unmet dependencies:", " libapache2-mod-fastcgi : Depends: apache2.2-common (>= 2.2.4) but it is not going to be installed"]}
```
I upgraded my local version of Ansible to 2.0.2.0 and received multiple warnings during provisioning like:

```bash
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your
playbooks so that the environment value uses the full variable syntax
('{{variable}}').
This feature will be removed in a future release.
Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
```
Updating the playbooks to use the [full variable syntax](http://docs.ansible.com/ansible/YAMLSyntax.html#gotchas) mitigated these warnings.

* updates config.vm.box to 'ubuntu/trusty64'
* updates ruby version to 2.2.5
* updates playbooks to use the full variable syntax and wraps all 'name' values in double quotes for consistency

@scottrigby, @cweagans, @ericduran and @conortm  
